### PR TITLE
Document developer portal & migrate demo clients to v3

### DIFF
--- a/case.md
+++ b/case.md
@@ -180,7 +180,7 @@ Same case-level fields as the Create or Update endpoint above, plus a single `me
 
 **`POST /v1/case/messages`**
 
-Adds a message to an existing case. **If the case doesn't exist, the API returns 200 with no action taken** (the message is silently dropped).
+Adds a message to an existing case. The response reflects the status returned by the downstream case service — if the case doesn't exist, expect a non-2xx status. Use `PUT /v1/case/messages` if you want the case created when it's missing.
 
 #### Request Body
 
@@ -218,7 +218,8 @@ Adds a message to an existing case. **If the case doesn't exist, the API returns
 
 #### Response
 
-- **200 OK** on success (even if case doesn't exist)
+- **200 OK** on success
+- A non-2xx status if the case doesn't exist (propagated from the case service)
 
 ---
 
@@ -344,5 +345,5 @@ Use the following template (fields can be modified, but the provided fields are 
 |-------------|-------------|
 | 200 | Success |
 | 400 | Bad Request — Invalid JSON, missing required fields, or validation errors |
-| 409 | Conflict — `externalIdentity` / `caseUid` already exists (conversation endpoints) |
+| 409 | Conflict — `caseUid` already exists |
 | 500 | Internal Server Error — Downstream service issues |

--- a/conversation.md
+++ b/conversation.md
@@ -19,15 +19,219 @@ See [readme.md](readme.md#authentication) for authentication details.
 - `externalIdentity` must be unique per organization
 - Audio processing priority is determined by conversation age (>24h = low priority)
 
+> **New integrations:** use **v3** (below). The v1 and v2 endpoints are [deprecated](#deprecated-endpoints) and kept only for backward compatibility.
+
 ---
 
-## API Endpoints
+## Create Conversation (v3)
 
-### Create Conversation v1 (Legacy)
+**`POST /v3/conversation`**
+
+The current endpoint for creating a conversation. Upload audio separately using the returned UID.
+
+v3 enforces strict validation of all required fields before processing and returns a lowercase `"uid"` in the response.
+
+### Required Fields
+
+```json
+{
+  "externalIdentity": "call-12345-2024",
+  "agentId": "agent-001",
+  "agentName": "John Sales",
+  "agentEmail": "john.sales@company.com",
+  "dateTime": "2024-01-15T14:30:00Z",
+  "subject": "Product demo call",
+  "customer": "+45 22 44 66 88"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `externalIdentity` | string | ✅ | Unique ID from your system — must be unique per organization |
+| `agentId` | string | ✅ | Agent identifier in your system |
+| `agentName` | string | ✅ | Agent display name |
+| `agentEmail` | string | ✅ | Agent email address |
+| `dateTime` | string (ISO 8601) | ✅ | When the conversation occurred |
+| `subject` | string | ✅ | Conversation subject |
+| `customer` | string | ✅ | Customer identifier (e.g. phone number) |
+
+### Optional Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `customerCompany` | string | — | Customer company name |
+| `labels` | string[] | — | Classification labels |
+| `status` | string | — | Conversation lifecycle status |
+| `hasConsent` | bool | `true` | When `false`, recording is deleted after analysis and insights are anonymised. |
+| `audioChannels` | string | `"Stereo"` | `"Mono1Speaker"`, `"Mono2Speaker"`, or `"Stereo"` |
+| `salesPersonAudioChannel` | int | `1` | `1` for left channel, `2` for right channel |
+| `team` | string | — | Team name — created in Capturi if it doesn't exist |
+| `cutAudio` | object[] | — | Audio segments to extract (see below) |
+| `customProp1`–`customProp10` | string | — | Custom text properties (must be configured in Capturi) |
+| `customNumberProp1`–`customNumberProp10` | float | — | Custom numeric properties |
+
+### Validation Rules
+
+All of these are enforced (returns 400 if any fail):
+- `externalIdentity` — must not be empty
+- `agentId` — must not be empty
+- `agentName` — must not be empty
+- `agentEmail` — must not be empty
+- `customer` — must not be empty
+- `dateTime` — must not be empty
+- `subject` — must not be empty
+
+### Cut Audio
+
+Extract specific time segments for focused analysis:
+
+```json
+{
+  "cutAudio": [
+    { "startSeconds": 120, "durationSeconds": 180 },
+    { "startSeconds": 600, "durationSeconds": 300 }
+  ]
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `startSeconds` | int | Segment start time in seconds (≥ 0) |
+| `durationSeconds` | int | Segment duration in seconds (≥ 1) |
+
+### Full Request Example
+
+```json
+{
+  "externalIdentity": "call-12345-2024",
+  "agentId": "agent-001",
+  "agentName": "John Sales",
+  "agentEmail": "john.sales@company.com",
+  "dateTime": "2024-01-15T14:30:00Z",
+  "subject": "Product demo call",
+  "customer": "+45 22 44 66 88",
+  "customerCompany": "ABC Corporation",
+  "labels": ["inbound", "demo", "qualified-lead"],
+  "status": "completed",
+  "hasConsent": true,
+  "audioChannels": "Stereo",
+  "salesPersonAudioChannel": 1,
+  "team": "Sales Team A",
+  "cutAudio": [
+    { "startSeconds": 120, "durationSeconds": 180 },
+    { "startSeconds": 600, "durationSeconds": 300 }
+  ],
+  "customProp1": "enterprise-tier",
+  "customProp2": "product-demo",
+  "customProp3": "q1-2024",
+  "customNumberProp1": 15000.0,
+  "customNumberProp2": 0.85,
+  "customNumberProp3": 3.5
+}
+```
+
+### Response
+
+```json
+{
+  "uid": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+> **Note:** v3 returns lowercase `"uid"`. Use this value for subsequent audio uploads.
+
+---
+
+## Audio Channel Configuration
+
+| Audio Channel | Description | Use Case |
+|---------------|-------------|----------|
+| `Mono1Speaker` | Single channel, one speaker | Phone recordings with single participant |
+| `Mono2Speaker` | Single channel, two speakers | Conference calls mixed to mono |
+| `Stereo` | Two channels (default) | Separate speaker channels |
+
+For stereo recordings, `salesPersonAudioChannel` specifies which channel contains the agent audio:
+- `1` = left channel (default)
+- `2` = right channel
+
+---
+
+## Upload Audio
+
+After creating a conversation, upload audio as a multipart form file.
+
+### Upload by Capturi Conversation UID
+
+**`POST /v1/audio/{conversation_uid}`**
+
+Use the UID returned from the create conversation response.
+
+### Upload by External ID
+
+**`POST /v1/audio/external/{external_id}`**
+
+Use the same external identity you provided when creating the conversation (`externalIdentity`).
+
+### Form Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `data` | file | ✅ | Audio file (binary) |
+| `spokenLanguage` | string | ❌ | Language code, e.g. `da-DK`, `en-US` |
+| `stereoConfig` | string | ❌ | `"AgentChannelOne"` or `"AgentChannelTwo"` |
+| `monoConfig` | string | ❌ | `"AgentOnly"`, `"CustomerOnly"`, or `"TwoSpeakers"` |
+
+**Content-Type:** `multipart/form-data`
+**Max upload size:** 1 GB
+**Response:** 200 OK on success
+
+### Upload Audio via Webhook (Async)
+
+For conversations created via the webhook endpoint (async flow).
+
+**`POST /v1/audio/webhook`**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `data` | file | ✅ | Audio file (binary) |
+| `externalId` | string | ✅ | Same external identity used when creating the conversation |
+
+> **Note:** Requires a webhook configuration for your organization. Contact Capturi to set this up.
+
+---
+
+## Processing Pipeline
+
+1. **Create Conversation** → Returns a UID
+2. **Upload Audio** → Use the UID with the audio upload endpoints above
+3. **ASR Processing** → Automatic speech-to-text (conversations >24h old get lower priority)
+4. **Analysis Available** → Results accessible via Capturi dashboard
+
+## Custom Properties
+
+- **Text properties** (`customProp1`–`customProp10`): 10 custom text fields
+- **Number properties** (`customNumberProp1`–`customNumberProp10`): 10 custom numeric fields
+- All custom properties must be configured in Capturi before use
+- Contact support to configure custom properties for your organization
+
+## Error Handling
+
+| Status Code | Description |
+|-------------|-------------|
+| 200 | Success — conversation created |
+| 400 | Bad Request — invalid JSON, missing required fields, or validation errors |
+| 409 | Conflict — `externalIdentity` already exists for this organization |
+| 500 | Internal Server Error — downstream service issues |
+
+---
+
+## Deprecated Endpoints
+
+> **Deprecated.** The v1 and v2 conversation endpoints remain available for backward compatibility but should not be used for new integrations. Use [v3](#create-conversation-v3) instead.
+
+### Create Conversation v1 (Deprecated)
 
 **`POST /v1/conversation`**
-
-> **Note:** v1 is maintained for backward compatibility. Use v2 or v3 for new integrations.
 
 #### Request Body
 
@@ -75,9 +279,9 @@ See [readme.md](readme.md#authentication) for authentication details.
 }
 ```
 
-#### Field Mapping (v1 → v2)
+#### Field Mapping (v1 → v3)
 
-| v1 Field | v2 Field |
+| v1 Field | v3 Field |
 |----------|----------|
 | `externalId` | `externalIdentity` |
 | `numberOfSpeakers` | `audioChannels` |
@@ -89,99 +293,11 @@ See [readme.md](readme.md#authentication) for authentication details.
 
 ---
 
-### Create Conversation v2 (Recommended)
+### Create Conversation v2 (Deprecated)
 
 **`POST /v2/conversation`**
 
-Creates a new conversation with the provided metadata. Upload audio separately using the returned UID.
-
-#### Required Fields
-
-```json
-{
-  "externalIdentity": "call-12345-2024",
-  "agentId": "agent-001",
-  "agentName": "John Sales",
-  "agentEmail": "john.sales@company.com",
-  "dateTime": "2024-01-15T14:30:00Z",
-  "subject": "Product demo call",
-  "customer": "+45 22 44 66 88"
-}
-```
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `externalIdentity` | string | ✅ | Unique ID from your system — must be unique per organization |
-| `agentId` | string | ✅ | Agent identifier in your system |
-| `agentName` | string | ✅ | Agent display name |
-| `agentEmail` | string | ✅ | Agent email address |
-| `dateTime` | string (ISO 8601) | ✅ | When the conversation occurred |
-| `subject` | string | ✅ | Conversation subject |
-| `customer` | string | ✅ | Customer identifier (e.g. phone number) |
-
-#### Optional Fields
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `customerCompany` | string | — | Customer company name |
-| `labels` | string[] | — | Classification labels |
-| `status` | string | — | Conversation lifecycle status |
-| `hasConsent` | bool | `true` | When `false`, recording is deleted after analysis and insights are anonymised. |
-| `audioChannels` | string | `"Stereo"` | `"Mono1Speaker"`, `"Mono2Speaker"`, or `"Stereo"` |
-| `salesPersonAudioChannel` | int | `1` | `1` for left channel, `2` for right channel |
-| `team` | string | — | Team name — created in Capturi if it doesn't exist |
-| `cutAudio` | object[] | — | Audio segments to extract (see below) |
-| `customProp1`–`customProp10` | string | — | Custom text properties (must be configured in Capturi) |
-| `customNumberProp1`–`customNumberProp9` | float | — | Custom numeric properties |
-
-#### Cut Audio
-
-Extract specific time segments for focused analysis:
-
-```json
-{
-  "cutAudio": [
-    { "startSeconds": 120, "durationSeconds": 180 },
-    { "startSeconds": 600, "durationSeconds": 300 }
-  ]
-}
-```
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `startSeconds` | int | Segment start time in seconds (≥ 0) |
-| `durationSeconds` | int | Segment duration in seconds (≥ 1) |
-
-#### Full Request Example
-
-```json
-{
-  "externalIdentity": "call-12345-2024",
-  "agentId": "agent-001",
-  "agentName": "John Sales",
-  "agentEmail": "john.sales@company.com",
-  "dateTime": "2024-01-15T14:30:00Z",
-  "subject": "Product demo call",
-  "customer": "+45 22 44 66 88",
-  "customerCompany": "ABC Corporation",
-  "labels": ["inbound", "demo", "qualified-lead"],
-  "status": "completed",
-  "hasConsent": true,
-  "audioChannels": "Stereo",
-  "salesPersonAudioChannel": 1,
-  "team": "Sales Team A",
-  "cutAudio": [
-    { "startSeconds": 120, "durationSeconds": 180 },
-    { "startSeconds": 600, "durationSeconds": 300 }
-  ],
-  "customProp1": "enterprise-tier",
-  "customProp2": "product-demo",
-  "customProp3": "q1-2024",
-  "customNumberProp1": 15000.0,
-  "customNumberProp2": 0.85,
-  "customNumberProp3": 3.5
-}
-```
+Identical request body to [v3](#create-conversation-v3), with one difference: v2 does not strictly validate required fields up front and returns an uppercase `"UID"` in the response.
 
 #### Response
 
@@ -191,118 +307,4 @@ Extract specific time segments for focused analysis:
 }
 ```
 
-> **Note:** The response field is uppercase `"UID"`. Use this value for subsequent audio uploads.
-
----
-
-### Create Conversation v3
-
-**`POST /v3/conversation`**
-
-Identical request body to v2 with two differences:
-1. **Stricter validation** — all required fields are validated before processing
-2. **Lowercase response** — returns `"uid"` instead of `"UID"`
-
-#### Validation Rules
-
-All of these are enforced (returns 400 if any fail):
-- `externalIdentity` — must not be empty
-- `agentId` — must not be empty
-- `agentName` — must not be empty
-- `agentEmail` — must not be empty
-- `customer` — must not be empty
-- `dateTime` — must not be empty
-- `subject` — must not be empty
-
-#### Response
-
-```json
-{
-  "uid": "550e8400-e29b-41d4-a716-446655440000"
-}
-```
-
-> **Important:** v3 returns lowercase `"uid"`, unlike v1/v2 which return uppercase `"UID"`.
-
----
-
-## Audio Channel Configuration
-
-| Audio Channel | Description | Use Case |
-|---------------|-------------|----------|
-| `Mono1Speaker` | Single channel, one speaker | Phone recordings with single participant |
-| `Mono2Speaker` | Single channel, two speakers | Conference calls mixed to mono |
-| `Stereo` | Two channels (default) | Separate speaker channels |
-
-For stereo recordings, `salesPersonAudioChannel` specifies which channel contains the agent audio:
-- `1` = left channel (default)
-- `2` = right channel
-
----
-
-## Upload Audio
-
-After creating a conversation, upload audio as a multipart form file.
-
-### Upload by Capturi Conversation UID
-
-**`POST /v1/audio/{conversation_uid}`**
-
-Use the UID returned from the create conversation response.
-
-### Upload by External ID
-
-**`POST /v1/audio/external/{external_id}`**
-
-Use the same external ID you provided when creating the conversation (`externalId` for v1, `externalIdentity` for v2/v3).
-
-### Form Fields
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `data` | file | ✅ | Audio file (binary) |
-| `spokenLanguage` | string | ❌ | Language code, e.g. `da-DK`, `en-US` |
-| `stereoConfig` | string | ❌ | `"AgentChannelOne"` or `"AgentChannelTwo"` |
-| `monoConfig` | string | ❌ | `"AgentOnly"`, `"CustomerOnly"`, or `"TwoSpeakers"` |
-
-**Content-Type:** `multipart/form-data`
-**Max upload size:** 1 GB
-**Response:** 200 OK on success
-
-### Upload Audio via Webhook (Async)
-
-For conversations created via the webhook endpoint (async flow).
-
-**`POST /v1/audio/webhook`**
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `data` | file | ✅ | Audio file (binary) |
-| `externalId` | string | ✅ | Same external identity used when creating the conversation |
-
-> **Note:** Requires a webhook configuration for your organization. Contact Capturi to set this up.
-
----
-
-## Processing Pipeline
-
-1. **Create Conversation** → Returns a UID
-2. **Upload Audio** → Use the UID with the audio upload endpoints above
-3. **ASR Processing** → Automatic speech-to-text (conversations >24h old get lower priority)
-4. **Analysis Available** → Results accessible via Capturi dashboard
-
-## Custom Properties
-
-- **Text properties** (`customProp1`–`customProp10`): 10 custom text fields
-- **Number properties** (`customNumberProp1`–`customNumberProp9`): 9 custom numeric fields
-- All custom properties must be configured in Capturi before use
-- Contact support to configure custom properties for your organization
-
-## Error Handling
-
-| Status Code | Description |
-|-------------|-------------|
-| 200 | Success — conversation created |
-| 400 | Bad Request — invalid JSON, missing required fields, or validation errors |
-| 409 | Conflict — `externalIdentity` already exists for this organization |
-| 500 | Internal Server Error — downstream service issues |
+> **Note:** v2 returns uppercase `"UID"`, unlike v3 which returns lowercase `"uid"`.

--- a/developer-portal.md
+++ b/developer-portal.md
@@ -1,0 +1,137 @@
+# Developer Portal
+
+The Developer Portal is a self-service web dashboard for inspecting your integration traffic against the Capturi Integrations API. Use it to watch requests live, debug errors, browse the conversations you've created, and ask an AI assistant for help building your integration.
+
+Access is granted through short-lived **magic links** — no separate portal login to manage.
+
+## Base URL
+
+```
+https://integrations.capturi.ai
+```
+
+## Quick start
+
+1. **Create a magic link** with your API token (see [below](#create-a-magic-link)).
+2. **Open the returned URL** in a browser. It signs you straight into the portal for your organisation.
+3. **Explore** the dashboard, request log, conversations, errors, and AI assistant.
+
+The link is valid for 24 hours. When it expires, create a new one.
+
+---
+
+## Create a Magic Link
+
+**`POST /v1/dev/magic-link`**
+
+Authenticated with your normal API token (see [readme.md](readme.md#authentication)). The link inherits the organisation scope of the token that created it, so portal data is limited to that organisation.
+
+### Request Body
+
+```json
+{
+  "name": "Jane Developer",
+  "email": "jane@partner.example",
+  "reasonForAccess": "Debugging conversation upload integration",
+  "singleUse": false
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | ✅ | Name of the person the link is for |
+| `email` | string | ✅ | Email of the person the link is for |
+| `reasonForAccess` | string | ✅ | Why access is being requested (recorded for audit) |
+| `singleUse` | bool | ❌ | When `true`, the link can only be used once. Defaults to `false`. |
+
+### Response
+
+```json
+{
+  "url": "https://integrations.capturi.ai/dev/8f3c…<64-char token>",
+  "expiresAt": "2026-07-09T12:00:00Z"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `url` | string | The magic link. Open in a browser to enter the portal. |
+| `expiresAt` | string (ISO 8601) | When the link expires (24 hours after creation). |
+
+### Notes
+
+- **Expiry:** links expire 24 hours after creation.
+- **Rate limit:** up to **5 links per hour per API token**. Exceeding this returns `429`.
+- **Treat the URL as a secret** — anyone with it can view your organisation's portal data until it expires. The token is shown only once, in the response, and cannot be retrieved again.
+
+| Status Code | Description |
+|-------------|-------------|
+| 200 | Success — link created |
+| 400 | Bad Request — missing `name`, `email`, or `reasonForAccess` |
+| 429 | Too Many Requests — hourly link limit reached |
+
+---
+
+## Using the Portal
+
+Open the magic-link URL to land on the dashboard at `/dev/{token}`. All views are scoped to your organisation.
+
+### Landing page
+
+`GET /dev` is a public landing page where you can paste a magic-link token if you have one but not the full URL.
+
+### Dashboard views
+
+| View | What it shows |
+|------|---------------|
+| **Dashboard** | At-a-glance statistics (request volume, success rate, average duration) with an AI summary. |
+| **Requests** | Every API request your integration has made, with method, endpoint, status, and duration. Open any request for full detail (headers, body, response). |
+| **Conversations** | The conversations your organisation has created, searchable by external ID or Capturi UID. |
+| **Errors** | Requests that failed (status ≥ 400), for quick debugging. |
+| **Live feed** | A real-time stream of incoming requests as they happen. |
+| **Docs** | The API documentation, embedded in the portal. |
+
+---
+
+## Portal JSON API
+
+The portal also exposes a read-only JSON API under the same magic-link token, useful for programmatic access or building your own tooling. All endpoints are authenticated by the `{token}` path segment.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/dev/{token}/api/requests` | List request logs (paginated; filter by `method`, `status`, `errors_only`) |
+| GET | `/dev/{token}/api/requests/{id}` | Full detail for a single request |
+| GET | `/dev/{token}/api/errors` | List failed requests (status ≥ 400) |
+| GET | `/dev/{token}/api/stats` | Dashboard statistics (`period` = `1h`, `24h`, `7d`, `30d`) |
+| GET | `/dev/{token}/api/conversations` | List conversations (paginated) |
+| GET | `/dev/{token}/api/conversations/{externalId}` | Get a conversation by external ID or UID |
+
+Pagination uses `limit` / `offset` for request logs and errors, and `limit` / `continuationToken` for conversations.
+
+---
+
+## AI Assistant
+
+The portal includes an AI assistant, purpose-built to help you integrate with the Capturi Integrations API. It is available when AI features are enabled for the environment.
+
+### Dashboard summary
+
+The dashboard shows an AI-generated summary of your recent integration activity — request volume, success rate, and anything notable in your traffic — written in plain language. Summaries are cached and can be refreshed on demand.
+
+### Chat assistant
+
+An interactive chat assistant that can:
+
+- **Answer integration questions** about the API, endpoints, and payloads.
+- **Inspect your recent requests** — it can look at your actual request log to help explain what happened and why a call failed.
+- **Generate code examples** for creating conversations, uploading audio, and calling the API in various languages.
+- **Help you build integration clients** for Puzzel from scratch.
+
+The assistant is scoped to your organisation and rate-limited (30 messages per hour). It is focused solely on Capturi API integration and will not answer off-topic questions.
+
+---
+
+## Support
+
+- **Email:** integrations@capturi.com
+- **GitHub Issues:** Create an issue on this repository

--- a/dotnet-csharp/AudioUploadClientExample/AudioUploadClientExample.csproj
+++ b/dotnet-csharp/AudioUploadClientExample/AudioUploadClientExample.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/dotnet-csharp/AudioUploadClientExample/Program.cs
+++ b/dotnet-csharp/AudioUploadClientExample/Program.cs
@@ -8,7 +8,7 @@ namespace AudioUploadClientExample
 {
     public static class Program
     {
-        private const string BaseApiUrl = "https://integrations.capturi.ai/v1/";
+        private const string BaseApiUrl = "https://integrations.capturi.ai/";
         private static string? _apiToken;
         private const bool UploadAudioUsingExternalConversationId = false;
 
@@ -64,7 +64,7 @@ namespace AudioUploadClientExample
         {
             using var httpClient  = SetupHttpClient();
             var request = CreateConversationRequest(externalConversationId);
-            var responseCreateConversation = await httpClient.PostAsJsonAsync("conversation", request);
+            var responseCreateConversation = await httpClient.PostAsJsonAsync("v3/conversation", request);
             if (responseCreateConversation.StatusCode != HttpStatusCode.OK)
             {
                 var contents = await responseCreateConversation.Content.ReadAsStringAsync();
@@ -82,24 +82,21 @@ namespace AudioUploadClientExample
         {
             var conversationRequest = new
             {
-                ExternalId = externalConversationId,
-                NumberOfSpeakers = 1,
-                PhoneNumber = "11223344",
-                Title = "Demo call",
-                Labels = new List<string>(),
-                DateTime = DateTime.UtcNow,
-                Outcome = "Success",
-                OutcomeReason = "We have a great product",
+                ExternalIdentity = externalConversationId,
                 AgentId = Guid.NewGuid(),
                 AgentName = "Agent Schmidt",
                 AgentEmail = "agent-schmidt@capturi.com",
+                DateTime = DateTime.UtcNow,
+                Subject = "Demo call",
+                Customer = "11223344",
+                Labels = new List<string>(),
             };
             return conversationRequest;
         }
         
         private class CreateConversationResponse
         {
-            [JsonPropertyName("UID")]
+            [JsonPropertyName("uid")]
             public string Uid { set; get; } = string.Empty;
         }
         
@@ -108,7 +105,7 @@ namespace AudioUploadClientExample
         {
             var httpClient = SetupHttpClient();
             var multipartFormDataContent = SetupMultipartFormDataContent(fileName);
-            var response = await httpClient.PostAsync($"audio/{conversationId}", multipartFormDataContent);
+            var response = await httpClient.PostAsync($"v1/audio/{conversationId}", multipartFormDataContent);
             if (response.StatusCode != HttpStatusCode.OK)
             {
                 var contents = await response.Content.ReadAsStringAsync();
@@ -122,7 +119,7 @@ namespace AudioUploadClientExample
             var httpClient = SetupHttpClient();
             var multipartFormDataContent = SetupMultipartFormDataContent(audioFileName);
 
-            var response = await httpClient.PostAsync($"audio/external/{externalConversationId}", multipartFormDataContent);
+            var response = await httpClient.PostAsync($"v1/audio/external/{externalConversationId}", multipartFormDataContent);
             if (response.StatusCode != HttpStatusCode.OK)
             {
                 var contents = await response.Content.ReadAsStringAsync();

--- a/go/main.go
+++ b/go/main.go
@@ -15,7 +15,7 @@ import (
 	"time"
 )
 
-const apiURL = "https://integrations.capturi.ai/v1/"
+const apiURL = "https://integrations.capturi.ai/"
 
 func main() {
 	//get api token from environment
@@ -32,21 +32,17 @@ func main() {
 
 	//Create conversation
 	createConversationRequest := CreateConversationRequest{
-		ExternalID:       uuid.NewString(),
-		NumberOfSpeakers: 1,
-		PhoneNumber:      "11223344",
-		Title:            "Demo call",
-		Labels:           nil,
-		DateTime:         time.Now(),
-		Outcome:          "Success",
-		OutcomeReason:    "We have a great product",
+		ExternalIdentity: uuid.NewString(),
 		AgentID:          uuid.NewString(),
 		AgentName:        "Agent Schmidt",
 		AgentEmail:       "agent-schmidt@capturi.com",
+		DateTime:         time.Now(),
+		Subject:          "Demo call",
+		Customer:         "11223344",
 	}
 
 	createConversationURL := *base
-	createConversationURL.Path += "conversation"
+	createConversationURL.Path += "v3/conversation"
 	//body
 	body := new(bytes.Buffer)
 	err = json.NewEncoder(body).Encode(createConversationRequest)
@@ -86,7 +82,7 @@ func main() {
 		log.Fatalf("Failed to decode response. Error: %v", err)
 	}
 
-	log.Printf("created a new conversation with uid: %s, and external id: %s", conversationCreatedResponse.UID, createConversationRequest.ExternalID)
+	log.Printf("created a new conversation with uid: %s, and external identity: %s", conversationCreatedResponse.UID, createConversationRequest.ExternalIdentity)
 
 	//Let's add some audio to the conversation.
 
@@ -103,7 +99,7 @@ func main() {
 	writer.Close()
 
 	uploadAudioURL := *base
-	uploadAudioURL.Path += fmt.Sprintf("audio/%s", conversationCreatedResponse.UID)
+	uploadAudioURL.Path += fmt.Sprintf("v1/audio/%s", conversationCreatedResponse.UID)
 
 	req, err = http.NewRequest("POST", uploadAudioURL.String(), body)
 	if err != nil {
@@ -136,25 +132,16 @@ func main() {
 }
 
 type CreateConversationRequest struct {
-	ExternalID       string    `json:"externalId"`
-	NumberOfSpeakers int       `json:"numberOfSpeakers"`
-	PhoneNumber      string    `json:"phoneNumber"`
-	Title            string    `json:"title"`
-	Labels           []string  `json:"labels"`
-	DateTime         time.Time `json:"datetime"`
-	Outcome          string    `json:"outcome"`
-	OutcomeReason    string    `json:"outcomeReason"`
+	ExternalIdentity string    `json:"externalIdentity"`
 	AgentID          string    `json:"agentId"`
 	AgentName        string    `json:"agentName"`
 	AgentEmail       string    `json:"agentEmail"`
-	Nps              float32   `json:"nps"`
-	Score            string    `json:"score"`
-	Direction        string    `json:"direction"`
-	TimeToAnswer     int32     `json:"timeToAnswer"`
-	Channel          string    `json:"channel"`
-	CaseID           string    `json:"caseId"`
+	DateTime         time.Time `json:"dateTime"`
+	Subject          string    `json:"subject"`
+	Customer         string    `json:"customer"`
+	Labels           []string  `json:"labels,omitempty"`
 }
 
 type ConversationCreatedResponse struct {
-	UID string
+	UID string `json:"uid"`
 }

--- a/readme.md
+++ b/readme.md
@@ -27,11 +27,25 @@ https://integrations.capturi.ai
 
 ---
 
+## Developer Portal
+
+The fastest way to explore and debug your integration is the **Developer Portal** — a self-service web dashboard where you can watch your API requests live, inspect errors, browse the conversations you've created, and ask an AI assistant for integration help (including generating client code).
+
+Access is granted through short-lived **magic links**: create one with your API token, open the returned URL in a browser, and you're in.
+
+```
+POST /v1/dev/magic-link
+```
+
+See [developer-portal.md](developer-portal.md) for full documentation, including the magic link endpoint, the portal views, the read-only JSON API, and the AI assistant.
+
+---
+
 ## Endpoints
 
 ### Conversations & Audio Upload
 
-See [conversation.md](conversation.md) for full documentation on conversation creation (v1, v2, v3) and audio upload.
+See [conversation.md](conversation.md) for full documentation on conversation creation and audio upload. Use the **v3** endpoint for new integrations; v1 and v2 are deprecated.
 
 ---
 
@@ -61,8 +75,8 @@ See [scim.md](scim.md) for Azure AD SCIM provisioning setup.
 
 ## Demo Clients
 
-- **Go**: [`go/`](go/) — Creates a v1 conversation and uploads audio
-- **.NET/C#**: [`dotnet-csharp/`](dotnet-csharp/) — Creates a v1 conversation and uploads audio
+- **Go**: [`go/`](go/) — Creates a conversation via the v3 endpoint and uploads audio (audio upload uses `/v1/audio`)
+- **.NET/C#**: [`dotnet-csharp/`](dotnet-csharp/) — Creates a conversation via the v3 endpoint and uploads audio (audio upload uses `/v1/audio`)
 
 ## Support
 


### PR DESCRIPTION
## Summary
- Refresh the external API docs to lead with the **developer portal** (magic-link access + AI features).
- Deprecate conversation **v1/v2** in favour of **v3**.
- Migrate the Go and .NET demo clients to the v3 endpoint.

## Changes
- **developer-portal.md** (new): `POST /v1/dev/magic-link`, portal views, read-only `/dev/{token}/api/*` JSON API, and the AI assistant (request inspection, integration-client generation).
- **readme.md**: prominent Developer Portal section near the top; v3-first conversation pointer; updated demo-client notes.
- **conversation.md**: v3 documented as the current endpoint; v1 and v2 moved into a Deprecated section; custom numeric properties corrected to `customNumberProp1`–`customNumberProp10`.
- **case.md**: corrected `POST /v1/case/messages` non-existent-case behaviour; fixed the error-table conflict field.
- **go/main.go** & **dotnet-csharp**: `POST /v3/conversation` with the v3 body and lowercase `uid` response; audio upload stays on `/v1/audio/*`.
- **.NET demo client**: target framework `net6.0` -> `net10.0`.

## Testing
- `go build ./...` and `go vet ./...` clean.
- `dotnet build` succeeds on net10.0 (0 errors).
- Documentation verified against the published Swagger and observed API behaviour. Only the public API surface is documented.