### PR TITLE
docs: clarify case contact `id` is conditionally required (outbound `from`)

### DIFF
--- a/case.md
+++ b/case.md
@@ -109,7 +109,7 @@ Creates a new case or updates an existing one if a case with the given `caseUid`
 |-------|------|----------|-------------|
 | `name` | string | ✅ | Contact display name |
 | `email` | string | ✅ | Contact email address |
-| `id` | string | ❌ | Contact identifier (used for agent lookup on outbound messages) |
+| `id` | string | ⚠️ | Contact identifier. **Required** on `from` for **outbound** messages (used to create/look up the sending agent — an empty value is rejected with `400`). Ignored on `from` for inbound messages and on all `to` contacts. |
 
 #### Response
 


### PR DESCRIPTION
## What

The case API Contact Object documented `id` as unconditionally optional (`❌`). That is misleading.

`from.id` is **required for outbound messages** — it is passed as the `externalUid` to the auth-service `create-or-get-user-by-external-id` endpoint to create/look up the sending agent. An empty value is filtered out and the request fails with `400` ("Failed to create or get agent"). It is ignored for inbound `from` contacts and for all `to` contacts.

## Change

- Contact Object table: `id` row changed from `❌` to `⚠️` with a description spelling out the conditional requirement.

Docs-only. Companion Swagger change lands in external-integrations PR #40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VV3G1FAzTBQGtpdSHtaqGP